### PR TITLE
Resolve project root through process.cwd()

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -5,9 +5,7 @@ import querystring from 'querystring'
 import https from 'https'
 import { config } from 'dotenv'
 
-const projectFolderPath = `${__dirname}/../../../..`
-// Needed when running npm start locally directly
-// const projectFolderPath = `${__dirname}/..`
+const projectFolderPath = process.cwd()
 
 config({ path: `${projectFolderPath}/.env` })
 


### PR DESCRIPTION
This changes to resolve the project root through `process.cwd()`, which is a much more reliable way to resolve it. I tested locally and this seems to work. This should also fix #20.